### PR TITLE
fix:크루관리 구현 방식 변경

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     extends: ['eslint:recommended', 'airbnb-base', 'prettier'],
     plugins: ['prettier'],
     rules: {
+        'semi': [2,'always'],
         'import/prefer-default-export': 'off',
         'import/extensions': ['off'],
         "class-methods-use-this": "off",

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ export const SELECTOR = {
     DELETE_CREW_BUTTON: "delete-crew-button",
     COURSE_SELECT: "course-select",
     MISSION_SELECT: "mission-select",
+    COURSE_MEMBER_LIST: "course-member-list",
     SHOW_TEAM_MATCHER_BUTTON: "show-team-matcher-button",
     TEAM_MEMBER_COUNT_INPUT: "team-member-count-input",
     MATCH_TEAM_BUTTON: "match-team-button",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,11 @@
 export const SELECTOR = {
-    APP:"app",
-    MAIN:"main",
+    APP: "app",
+    MAIN: "main",
     CREW_TAB: "crew-tab",
     TEAM_TAB: "team-tab",
-    MATCHING_SECTION:"matching-section",
-    CREW_TAB_DETAIL:"crew-tab-detail",
+    MATCHING_SECTION: "matching-section",
+    CREW_TAB_DETAIL: "crew-tab-detail",
+    CREW_TBODY: "crew-tbody",
     FRONTEND_COURSE_INPUT: "frontend-course",
     BACKEND_COURSE_INPUT: "backend-course",
     CREW_NAME_INPUT: "crew-name-input",
@@ -14,4 +15,9 @@ export const SELECTOR = {
     SHOW_TEAM_MATCHER_BUTTON: "show-team-matcher-button",
     TEAM_MEMBER_COUNT_INPUT: "team-member-count-input",
     MATCH_TEAM_BUTTON: "match-team-button",
+};
+
+export const COURSE_NAME_KR = {
+    frontend: "프론트엔드",
+    backend: "백엔드"
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ export const SELECTOR = {
     BACKEND_COURSE_INPUT: "backend-course",
     CREW_NAME_INPUT: "crew-name-input",
     ADD_CREW_BUTTON: "add-crew-button",
+    DELETE_CREW_BUTTON: "delete-crew-button",
     COURSE_SELECT: "course-select",
     MISSION_SELECT: "mission-select",
     SHOW_TEAM_MATCHER_BUTTON: "show-team-matcher-button",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
 import { MatcherHandler } from "./matcherHandler.js";
 
-const matcherHandler = new MatcherHandler();
+const mockData = {
+    frontend:["a","b"],
+    backend:["c","d"],
+}
+
+const matcherHandler = new MatcherHandler(mockData);

--- a/src/matcherHandler.js
+++ b/src/matcherHandler.js
@@ -5,11 +5,18 @@ export class MatcherHandler {
     constructor() {
         this.matcher = new Matcer();
         this.view = new View();
-        this.view.registerCrewTabClickEvent(this.requestSetCrew);
+        this.view.registerManageTabClickEventListener({
+            addFn:this.requestSetCrew,
+            deleteFn:this.requestDeleteCrew,
+        });
     }
     
     requestSetCrew = (crewInfo) => {
         this.matcher.setCrew(crewInfo);
+        this.view.renderManageCrewList(this.matcher.getCrewList());
+    }
+    requestDeleteCrew = (crewInfo) => {
+        this.matcher.deleteCrew(crewInfo);
         this.view.renderManageCrewList(this.matcher.getCrewList());
     }
 }

--- a/src/matcherHandler.js
+++ b/src/matcherHandler.js
@@ -9,6 +9,7 @@ export class MatcherHandler {
             addFn:this.requestSetCrew,
             deleteFn:this.requestDeleteCrew,
         });
+        this.view.registerTeamTabClickEventListener();
     }
     
     requestSetCrew = (crewInfo) => {

--- a/src/matcherHandler.js
+++ b/src/matcherHandler.js
@@ -1,7 +1,7 @@
 import View from "./view";
 
 export class MatcherHandler {
-    constructor() {
-        this.view = new View();
+    constructor(data) {
+        this.view = new View(data);
     }
 }

--- a/src/matcherHandler.js
+++ b/src/matcherHandler.js
@@ -1,7 +1,15 @@
 import View from "./view";
+import { Matcer } from "./model/matcer.js";
 
 export class MatcherHandler {
-    constructor(data) {
-        this.view = new View(data);
+    constructor() {
+        this.matcher = new Matcer();
+        this.view = new View();
+        this.view.registerCrewTabClickEvent(this.requestSetCrew);
+    }
+    
+    requestSetCrew = (crewInfo) => {
+        this.matcher.setCrew(crewInfo);
+        this.view.renderManageCrewList(this.matcher.getCrewList());
     }
 }

--- a/src/model/matcer.js
+++ b/src/model/matcer.js
@@ -1,0 +1,26 @@
+export class Matcer {
+    #crewList;
+    
+    constructor() {
+        if (Matcer.instance) {
+            return Matcer.instance;
+        }
+        Matcer.instance = this;
+        this.#crewList = {
+            frontend: ["a", "b"],
+            backend: ["c", "d"],
+        }
+    }
+    
+    getPositionList(posittion) {
+        return this.#crewList[ posittion ];
+    }
+    
+    getCrewList() {
+        return this.#crewList
+    }
+    
+    setCrew = ({ position, name }) => {
+        this.#crewList[ position ].push(name);
+    }
+}

--- a/src/model/matcer.js
+++ b/src/model/matcer.js
@@ -23,4 +23,8 @@ export class Matcer {
     setCrew = ({ position, name }) => {
         this.#crewList[ position ].push(name);
     }
+    
+    deleteCrew = ({ position, idx }) => {
+        this.#crewList[ position ].splice(idx,1);
+    }
 }

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -6,58 +6,79 @@ import { Matcer } from "../model/matcer.js";
 
 export default class {
     #currentCourse;
+    #currentMisson;
     
     constructor() {
         this.matcher = new Matcer();
-        this.#currentCourse = "";
         this.initPage();
     }
     
     initPage() {
         renderTemplate(SELECTOR.APP, Templates.HEADER);
         renderTemplate(SELECTOR.APP, Templates.MAIN);
+        this.registerHeaderEventListener();
     }
     
-    registerCrewTabClickEvent(callBackFn) {
-        $(`#${SELECTOR.CREW_TAB}`).addEventListener("click", () => {
+    registerHeaderEventListener() {
+        $("header").addEventListener("click", (e) => {
+            if (e.target.id === SELECTOR.CREW_TAB) {
+                this.showCrewTab();
+            }
+            if (e.target.id === SELECTOR.TEAM_TAB) {
+                this.showTeamTab();
+            }
+        });
+    }
+    
+    registerManageTabClickEventListener({ addFn, deleteFn }) {
+        $(SELECTOR.MAIN).addEventListener("click", (e) => {
+            if (e.target.id === SELECTOR.FRONTEND_COURSE_INPUT || e.target.id === SELECTOR.BACKEND_COURSE_INPUT) {
+                this.showManageSection(e);
+            }
+            if (e.target.id === SELECTOR.ADD_CREW_BUTTON) {
+                this.requestAddCrew(addFn);
+            }
+            if (e.target.className === SELECTOR.DELETE_CREW_BUTTON) {
+                this.requestDeleteCrew(e,deleteFn);
+            }
+        });
+    }
+    
+    showCrewTab() {
             clearNode(SELECTOR.MAIN);
             renderTemplate(SELECTOR.MAIN, Templates.MANAGE_COURSE_SELECT);
-            this.registerFrontendButtonClickEvent(callBackFn);
-            this.registerBackendButtonClickEvent(callBackFn);
+    }
+    
+    showTeamTab(){
+        clearNode(SELECTOR.MAIN);
+        renderTemplate(SELECTOR.MAIN, Templates.MATCHING_TEAM_SELECT_SECTION);
+    }
+    
+    showManageSection(e) {
+        this.#currentCourse = e.target.value;
+        this.renderCourseManageSection();
+        this.renderManageCrewList(this.matcher.getCrewList());
+    }
+    
+    requestAddCrew(callbackFn) {
+        $("form").addEventListener("submit", (e) => {
+            e.preventDefault();
+        });
+        callbackFn({
+            position: this.#currentCourse, name: $(`#${SELECTOR.CREW_NAME_INPUT}`).value
         });
     }
     
-    registerFrontendButtonClickEvent(callBackFn) {
-        $(`#${SELECTOR.FRONTEND_COURSE_INPUT}`).addEventListener("click", (e) => {
-            this.#currentCourse = e.target.value;
-            this.renderCourseManageSection(callBackFn);
-            this.renderManageCrewList(this.matcher.getCrewList());
+    requestDeleteCrew(e,callbackFn) {
+        callbackFn({
+            position: this.#currentCourse,
+            idx: e.target.dataset.targetIndex
         });
     }
     
-    registerBackendButtonClickEvent(callBackFn) {
-        $(`#${SELECTOR.BACKEND_COURSE_INPUT}`).addEventListener("click", (e) => {
-            this.#currentCourse = e.target.value;
-            this.renderCourseManageSection(callBackFn);
-            this.renderManageCrewList(this.matcher.getCrewList());
-        })
-    }
-    
-    renderCourseManageSection(callbackFn) {
+    renderCourseManageSection() {
         removeClassNodes(SELECTOR.CREW_TAB_DETAIL);
         renderTemplate(SELECTOR.MAIN, Templates.COURSE_MANAGE_SECTION(COURSE_NAME_KR[ this.#currentCourse ]));
-        this.registerAddCrewButtonEvent(callbackFn);
-    }
-    
-    registerAddCrewButtonEvent(callbackFn) {
-        $("form").addEventListener("submit", (e) => {
-            e.preventDefault()
-        });
-        $(`#${SELECTOR.ADD_CREW_BUTTON}`).addEventListener("click", () => {
-            callbackFn({
-                position: this.#currentCourse, name: $(`#${SELECTOR.CREW_NAME_INPUT}`).value
-            });
-        })
     }
     
     renderManageCrewList(crewList) {

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -53,22 +53,28 @@ export default class {
     
     registerFrontendButtonClickEvent() {
         $(`#${SELECTOR.FRONTEND_COURSE_INPUT}`).addEventListener("click", (e) => {
-            this.renderCourseSection(e);
+            this.renderCourseSection({ courseName:e.target.value });
             this.preventDefault();
         });
     }
     
     registerBackendButtonClickEvent() {
         $(`#${SELECTOR.BACKEND_COURSE_INPUT}`).addEventListener("click", (e) => {
-            this.renderCourseSection(e);
+            this.renderCourseSection({ courseName:e.target.value });
             this.preventDefault();
         });
     }
     
-    renderCourseSection(e){
-        this.#currentCourseName = e.target.value;
+    getCourseManageSectionTemplate(courseName){
+        return Templates.COURSE_MANAGE_SECTION(
+            this.getLabelText(courseName),
+            Templates.CREW_TABLE_ITEMS(this.#currentCrewData[courseName])
+        )
+    }
+    
+    renderCourseSection({ courseName }){
+        this.#currentCourseName = courseName;
         removeClassNodes(SELECTOR.CREW_TAB_DETAIL);
-        renderTemplate(SELECTOR.MAIN, Templates
-        .COURSE_MANAGE_SECTION(this.getLabelText(this.#currentCourseName),Templates.CREW_TABLE_ITEMS(this.#currentCrewData[this.#currentCourseName])))
+        renderTemplate(SELECTOR.MAIN, this.getCourseManageSectionTemplate(this.#currentCourseName))
     }
 }

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -1,7 +1,7 @@
 import { $ } from "../utils.js"
 import { COURSE_NAME_KR, SELECTOR } from "../constants.js";
 import { Templates } from "./templates.js";
-import { clearNode, removeClassNodes, renderTemplate } from "./viewHelper.js";
+import { clearNode, getSelectedName, removeClassNodes, renderTemplate } from "./viewHelper.js";
 import { Matcer } from "../model/matcer.js";
 
 export default class {
@@ -21,6 +21,7 @@ export default class {
     
     registerHeaderEventListener() {
         $("header").addEventListener("click", (e) => {
+            e.preventDefault();
             if (e.target.id === SELECTOR.CREW_TAB) {
                 this.showCrewTab();
             }
@@ -39,17 +40,26 @@ export default class {
                 this.requestAddCrew(addFn);
             }
             if (e.target.className === SELECTOR.DELETE_CREW_BUTTON) {
-                this.requestDeleteCrew(e,deleteFn);
+                this.requestDeleteCrew(e, deleteFn);
+            }
+        });
+    }
+    
+    registerTeamTabClickEventListener() {
+        $(SELECTOR.MAIN).addEventListener("click", (e) => {
+            e.preventDefault();
+            if (e.target.id === SELECTOR.SHOW_TEAM_MATCHER_BUTTON) {
+                this.showTeamMatchingSectionDetail();
             }
         });
     }
     
     showCrewTab() {
-            clearNode(SELECTOR.MAIN);
-            renderTemplate(SELECTOR.MAIN, Templates.MANAGE_COURSE_SELECT);
+        clearNode(SELECTOR.MAIN);
+        renderTemplate(SELECTOR.MAIN, Templates.MANAGE_COURSE_SELECT);
     }
     
-    showTeamTab(){
+    showTeamTab() {
         clearNode(SELECTOR.MAIN);
         renderTemplate(SELECTOR.MAIN, Templates.MATCHING_TEAM_SELECT_SECTION);
     }
@@ -60,16 +70,24 @@ export default class {
         this.renderManageCrewList(this.matcher.getCrewList());
     }
     
+    showTeamMatchingSectionDetail() {
+        removeClassNodes(SELECTOR.MATCHING_SECTION);
+        this.#currentCourse = $(`#${SELECTOR.COURSE_SELECT}`).value;
+        this.#currentMisson = $(`#${SELECTOR.MISSION_SELECT}`).value;
+        renderTemplate(SELECTOR.MAIN, Templates.MATCHING_SECTION({
+            course: getSelectedName($(`#${SELECTOR.COURSE_SELECT}`)),
+            mission:getSelectedName($(`#${SELECTOR.MISSION_SELECT}`))
+        }));
+        this.renderCourseMemberList();
+    }
+    
     requestAddCrew(callbackFn) {
-        $("form").addEventListener("submit", (e) => {
-            e.preventDefault();
-        });
         callbackFn({
             position: this.#currentCourse, name: $(`#${SELECTOR.CREW_NAME_INPUT}`).value
         });
     }
     
-    requestDeleteCrew(e,callbackFn) {
+    requestDeleteCrew(e, callbackFn) {
         callbackFn({
             position: this.#currentCourse,
             idx: e.target.dataset.targetIndex
@@ -84,5 +102,11 @@ export default class {
     renderManageCrewList(crewList) {
         clearNode(SELECTOR.CREW_TBODY);
         renderTemplate(SELECTOR.CREW_TBODY, Templates.CREW_TABLE_ITEMS(crewList[ this.#currentCourse ]));
+    }
+    
+    renderCourseMemberList(){
+        this.matcher.getPositionList(this.#currentCourse).map(name=>{
+            renderTemplate(SELECTOR.COURSE_MEMBER_LIST,Templates.COURSE_MEMBER_LIST_ITEM(name));
+        })
     }
 }

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -4,49 +4,71 @@ import { Templates } from "./templates.js";
 import { clearNode, removeClassNodes, renderTemplate } from "./viewHelper.js";
 
 export default class {
-    constructor() {
+    #currentCourseName;
+    #currentCrewData;
+    
+    constructor(data) {
+        this.#currentCrewData = data;
+        this.#currentCourseName = "";
+        this.initFirstPage();
+    }
+    
+    initFirstPage(){
         renderTemplate(SELECTOR.APP, Templates.HEADER);
         renderTemplate(SELECTOR.APP, Templates.MAIN);
-        this.registerCrewTabClickEvent()
+        this.registerCrewTabClickEvent();
         this.registerTeamMatchingTabClickEvent();
+    }
+    
+    preventDefault() {
+        $("form").addEventListener("submit", e => {
+            e.preventDefault();
+        });
+    }
+    
+    getLabelText(forValue) {
+        return $("label[for='" + forValue + "']").innerText;
     }
     
     registerCrewTabClickEvent() {
         $(`#${SELECTOR.CREW_TAB}`).addEventListener("click", () => {
             clearNode(SELECTOR.MAIN);
-            renderTemplate(SELECTOR.MAIN,Templates.COURSE_SELECT);
+            renderTemplate(SELECTOR.MAIN, Templates.COURSE_SELECT);
             this.registerFrontendButtonClickEvent();
             this.registerBackendButtonClickEvent();
-            }
-        );
+        });
     }
     
     registerTeamMatchingTabClickEvent() {
         $(`#${SELECTOR.TEAM_TAB}`).addEventListener("click", () => {
-                clearNode(SELECTOR.MAIN);
-                renderTemplate(SELECTOR.MAIN,Templates.MATCHING_SECTION);
-            }
-        );
+            clearNode(SELECTOR.MAIN);
+            renderTemplate(SELECTOR.MAIN, Templates.MATCHING_SECTION);
+        });
     }
     
-    showResult(){
+    showResult() {
         removeClassNodes(SELECTOR.MATCHING_SECTION);
-        renderTemplate(SELECTOR.MAIN,Templates.MATCHING_RESULT_SECTION);
+        renderTemplate(SELECTOR.MAIN, Templates.MATCHING_RESULT_SECTION);
     }
     
-    registerFrontendButtonClickEvent(){
-        $(`#${SELECTOR.FRONTEND_COURSE_INPUT}`).addEventListener("click", () => {
-                removeClassNodes(SELECTOR.CREW_TAB_DETAIL);
-                renderTemplate(SELECTOR.MAIN,Templates.FRONTEND_COURSE_MANAGE_SECTIONS);
-            }
-        );
+    registerFrontendButtonClickEvent() {
+        $(`#${SELECTOR.FRONTEND_COURSE_INPUT}`).addEventListener("click", (e) => {
+            this.renderCourseSection(e);
+            this.preventDefault();
+        });
     }
     
-    registerBackendButtonClickEvent(){
-        $(`#${SELECTOR.BACKEND_COURSE_INPUT}`).addEventListener("click", () => {
-                removeClassNodes(SELECTOR.CREW_TAB_DETAIL);
-                renderTemplate(SELECTOR.MAIN,Templates.BACKEND_COURSE_MANAGE_SECTIONS);
-            }
-        );
+    registerBackendButtonClickEvent() {
+        $(`#${SELECTOR.BACKEND_COURSE_INPUT}`).addEventListener("click", (e) => {
+            this.renderCourseSection(e);
+            this.preventDefault();
+        });
+    }
+    
+    renderCourseSection(e){
+        this.#currentCourseName = e.target.value;
+        removeClassNodes(SELECTOR.CREW_TAB_DETAIL);
+        renderTemplate(SELECTOR.MAIN, Templates
+        .COURSE_MANAGE_SECTION(this.getLabelText(this.#currentCourseName),Templates.CREW_TABLE_ITEMS(this.#currentCrewData[this.#currentCourseName])))
     }
 }

--- a/src/view/templates.js
+++ b/src/view/templates.js
@@ -84,29 +84,9 @@ export const Templates = {
             </form>
         </section>
     `,
-    MATCHING_SECTION: `
-    <section>
-      <h3>팀 매칭을 관리할 코스, 미션을 선택하세요.</h3>
-      <form>
-        <select id="course-select">
-          <option value="frontend">프론트엔드</option>
-          <option value="backend">백엔드</option>
-        </select>
-        <select id="mission-select">
-          <option value="baseball">숫자야구게임</option>
-          <option value="racingcar">자동차경주</option>
-          <option value="lotto">로또</option>
-          <option value="shopping-cart">장바구니</option>
-          <option value="payments">결제</option>
-          <option value="subway">지하철노선도</option>
-          <option value="performance">성능개선</option>
-          <option value="deploy">배포</option>
-        </select>
-        <button id="show-team-matcher-button">확인</button>
-      </form>
-    </section>
+    MATCHING_SECTION:({ course, mission })=> `
     <section class="matching-section">
-      <h3>프론트엔드 숫자야구게임 미션의 팀 매칭</h3>
+      <h3>${course} ${mission} 미션의 팀 매칭</h3>
       <div>
         <div>
           <p>아직 매칭된 팀이 없습니다. 팀을 매칭하겠습니까?</p>
@@ -117,12 +97,13 @@ export const Templates = {
           </form>
         </div>
         <h4>크루 목록</h4>
-        <ul>
-          <li>준</li>
-          <li>포코</li>
+        <ul id="course-member-list">
         </ul>
       </div>
     </section>
+    `,
+    COURSE_MEMBER_LIST_ITEM:(name)=>`
+        <li>${name}</li>
     `,
     MATCHING_RESULT_SECTION: `
     <section>

--- a/src/view/templates.js
+++ b/src/view/templates.js
@@ -57,11 +57,33 @@ export const Templates = {
             <td>${idx + 1}</td>
             <td>${crewName}</td>
             <td>
-            <button class="delete-crew-button">삭제</button>
+            <button data-target-index=${idx} class="delete-crew-button">삭제</button>
             </td>
         </tr>
     `).join("")
     ,
+    MATCHING_TEAM_SELECT_SECTION: `
+        <section>
+            <h3>팀 매칭을 관리할 코스, 미션을 선택하세요.</h3>
+            <form>
+            <select id="course-select">
+                <option value="frontend">프론트엔드</option>
+                <option value="backend">백엔드</option>
+            </select>
+            <select id="mission-select">
+                <option value="baseball">숫자야구게임</option>
+                <option value="racingcar">자동차경주</option>
+                <option value="lotto">로또</option>
+                <option value="shopping-cart">장바구니</option>
+                <option value="payments">결제</option>
+                <option value="subway">지하철노선도</option>
+                <option value="performance">성능개선</option>
+                <option value="deploy">배포</option>
+            </select>
+            <button id="show-team-matcher-button">확인</button>
+            </form>
+        </section>
+    `,
     MATCHING_SECTION: `
     <section>
       <h3>팀 매칭을 관리할 코스, 미션을 선택하세요.</h3>

--- a/src/view/templates.js
+++ b/src/view/templates.js
@@ -15,7 +15,7 @@ export const Templates = {
   </header>
     `,
     MAIN: `<main id="main"></main>`,
-    COURSE_SELECT: `
+    MANAGE_COURSE_SELECT: `
     <section>
       <h3>크루를 관리할 코스를 선택해주세요</h3>
       <div>
@@ -26,7 +26,7 @@ export const Templates = {
       </div>
     </section>
     `,
-    COURSE_MANAGE_SECTION:(courseName,crewTableItems)=>`
+    COURSE_MANAGE_SECTION: (courseName) => `
     <section class="crew-tab-detail">
             <h3>${courseName} 크루 관리</h3>
             <form>
@@ -45,17 +45,16 @@ export const Templates = {
             <th>관리</th>
             </tr>
             </thead>
-            <tbody>
-            ${crewTableItems}
+            <tbody id="crew-tbody">
         </tbody>
         </table>
     </section>
     `
     ,
-    CREW_TABLE_ITEMS:(crewList)=>
-        crewList.map((crewName,idx)=>`
+    CREW_TABLE_ITEMS: (crewList) =>
+        crewList.map((crewName, idx) => `
         <tr>
-            <td>${idx+1}</td>
+            <td>${idx + 1}</td>
             <td>${crewName}</td>
             <td>
             <button class="delete-crew-button">삭제</button>
@@ -63,7 +62,7 @@ export const Templates = {
         </tr>
     `).join("")
     ,
-    MATCHING_SECTION:`
+    MATCHING_SECTION: `
     <section>
       <h3>팀 매칭을 관리할 코스, 미션을 선택하세요.</h3>
       <form>
@@ -103,7 +102,7 @@ export const Templates = {
       </div>
     </section>
     `,
-    MATCHING_RESULT_SECTION:`
+    MATCHING_RESULT_SECTION: `
     <section>
       <h3>프론트엔드 숫자야구게임 조회</h3>
       <p>팀이 매칭되었습니다.</p>
@@ -117,4 +116,4 @@ export const Templates = {
     </section>
     `
     
-}
+};

--- a/src/view/templates.js
+++ b/src/view/templates.js
@@ -26,68 +26,43 @@ export const Templates = {
       </div>
     </section>
     `,
-    FRONTEND_COURSE_MANAGE_SECTIONS:`
-        <section class="crew-tab-detail">
-      <h3>프론트엔드 크루 관리</h3>
-      <form>
-        <label>크루 이름</label>
-        <input id="crew-name-input" type="text" />
-        <button id="add-crew-button">확인</button>
-      </form>
-    </section>
+    COURSE_MANAGE_SECTION:(courseName,crewTableItems)=>`
     <section class="crew-tab-detail">
-      <h3>프론트엔드 크루 목록</h3>
-      <table id="crew-table" border="1">
-        <thead>
-          <tr>
+            <h3>${courseName} 크루 관리</h3>
+            <form>
+                <label>크루 이름</label>
+                <input id="crew-name-input" type="text" />
+                <button id="add-crew-button">확인</button>
+            </form>
+        </section>
+    <section class="crew-tab-detail">
+            <h3>${courseName} 크루 목록</h3>
+            <table id="crew-table" border="1">
+            <thead>
+            <tr>
             <th></th>
             <th>크루</th>
             <th>관리</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>1</td>
-            <td>준</td>
-            <td>
-              <button class="delete-crew-button">삭제</button>
-            </td>
-          </tr>
+            </tr>
+            </thead>
+            <tbody>
+            ${crewTableItems}
         </tbody>
-      </table>
+        </table>
     </section>
-    `,
-    BACKEND_COURSE_MANAGE_SECTIONS:`
-        <section class="crew-tab-detail">
-      <h3>백엔드 크루 관리</h3>
-      <form>
-        <label>크루 이름</label>
-        <input id="crew-name-input" type="text" />
-        <button id="add-crew-button">확인</button>
-      </form>
-    </section>
-    <section class="crew-tab-detail">
-      <h3>백엔드 크루 목록</h3>
-      <table id="crew-table" border="1">
-        <thead>
-          <tr>
-            <th></th>
-            <th>크루</th>
-            <th>관리</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>1</td>
-            <td>준</td>
+    `
+    ,
+    CREW_TABLE_ITEMS:(crewList)=>
+        crewList.map((crewName,idx)=>`
+        <tr>
+            <td>${idx+1}</td>
+            <td>${crewName}</td>
             <td>
-              <button class="delete-crew-button">삭제</button>
+            <button class="delete-crew-button">삭제</button>
             </td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-    `,
+        </tr>
+    `).join("")
+    ,
     MATCHING_SECTION:`
     <section>
       <h3>팀 매칭을 관리할 코스, 미션을 선택하세요.</h3>

--- a/src/view/viewHelper.js
+++ b/src/view/viewHelper.js
@@ -13,3 +13,7 @@ export function removeClassNodes(targetClass) {
         node.remove();
     });
 }
+
+export function getSelectedName(target){
+    return target.options[target.selectedIndex].text;
+}

--- a/src/view/viewHelper.js
+++ b/src/view/viewHelper.js
@@ -1,7 +1,7 @@
 import { $ } from "../utils.js";
 
-export function renderTemplate(parentId,chiledNode) {
-    $(`#${parentId}`).insertAdjacentHTML("beforeend",chiledNode);
+export function renderTemplate(parentId, chiledNode) {
+    $(`#${parentId}`).insertAdjacentHTML("beforeend", chiledNode);
 }
 
 export function clearNode(targetId) {
@@ -9,7 +9,7 @@ export function clearNode(targetId) {
 }
 
 export function removeClassNodes(targetClass) {
-    document.querySelectorAll(`.${targetClass}`).forEach(node=>{
+    document.querySelectorAll(`.${targetClass}`).forEach(node => {
         node.remove();
     });
 }


### PR DESCRIPTION
# 크루관리 탭 구현 방식 변경 PR입니다.
- view의 state를 만들고 관리하며 화면을 렌더링하도록 변경하였습니다
우테코 프론트엔드 강사님의 비슷한 과제 구현 영상을 보고 해당 방식으로 구현해보았는데, 익숙하지않은 방식으로 시행착오를 겪고 있습니다.
뷰를 다양한 객체로 쪼개야할 것 같은데 엄두를 못내고있는 상태입니다.
원래 방식대로 구현할 지 고민입니다.